### PR TITLE
Feature: Add support for nouns

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -1,0 +1,114 @@
+package utils
+
+// This package contains utility functions used by the saol package.
+
+import (
+  "fmt"
+  "strings"
+  "github.com/michalspano/saol.se-cli/types"
+)
+
+/*
+ * This is a helper function that is used to format the "övrig(a) form(er)" 
+ * section of a word. It takes a slice of strings (an array) and returns a
+ * pair (array) of strings in an array (a 2D array). This way, we can assign
+ * each form an additional explanation in a reusable way.
+ */
+func FormatOtherForms(arr []string) [][]string {
+	tmp := make([][]string, 0)
+	for i := 0; i < len(arr); i += 2 {
+		tmp = append(tmp, []string{arr[i], arr[i+1]})
+	}
+	return tmp
+}
+
+/*
+ * This function is responsible for creating a `Noun struct` given the specifications
+ * and is then assigned to the `Word struct`'s `TypeDef` field. The return value is a pointer
+ * to the newly created `Noun struct`. Furthermore, given the `rules` map, the function
+ * will also assign the `Plural` and `OtherForms` fields of the `Noun struct` if the
+ * rules allow so.
+ */
+func CreateNoun(grammar []string, rules map[string]bool, prefix string) *types.Noun {
+	noun := types.Noun{}
+
+	noun.Suffix           = prefix
+	noun.SgIndefinite     = grammar[0]
+	noun.SgIndefiniteGen  = grammar[2]
+	noun.SgDefinite       = grammar[4]
+	noun.SgDefiniteGen    = grammar[6]
+
+	if rules["plural"] {
+		noun.PlIndefinite     = grammar[8]
+		noun.PlIndefiniteGen  = grammar[10]
+		noun.PlDefinite       = grammar[12]
+		noun.PlDefiniteGen    = grammar[14]
+	}
+	if rules["ovrigt"] {
+		noun.OtherForms = FormatOtherForms(grammar[16:])
+	}
+
+	return &noun
+}
+
+/*
+ * This function removes all whitespaces and converts the string to lowercase.
+ * It is a helper function used to ensure that the word types stay consistent.
+ */
+func FormatWordType(T string) string {
+  tmp := strings.Replace(T, " ", "", -1)
+  return strings.ToLower(tmp)
+}
+
+/*
+ * The `formatNoun` function takes a Word struct (assumed to be a noun) and returns a string.
+ * The string contains all the information in a formatted, human-readable
+ * way, based on the formatting per SAOL's website.
+ */
+func FormatNoun(w types.Word) string {
+	var output strings.Builder
+
+	output.WriteString(fmt.Sprintf("%s %s %s\n", w.BaseForm, w.WordType, w.TypeDef.(*types.Noun).Suffix))
+
+  // If there's only one meaning, add a bullet point (instead of a number).
+	if len(w.Meanings) == 1 {
+		output.WriteString(fmt.Sprintf("•%s\n", w.Meanings[0]))
+	} else {
+		for i, meaning := range w.Meanings {
+			output.WriteString(fmt.Sprintf("%d. %s\n", i+1, meaning))
+		}
+	}
+
+	output.WriteString("\n")
+	output.WriteString("Singular\n")
+	output.WriteString(fmt.Sprintf("%s\t obestämd form\n", w.TypeDef.(*types.Noun).SgIndefinite))
+	output.WriteString(fmt.Sprintf("%s\t obestämd form genitiv\n", w.TypeDef.(*types.Noun).SgIndefiniteGen))
+	output.WriteString(fmt.Sprintf("%s\t bestämd form\n", w.TypeDef.(*types.Noun).SgDefinite))
+	output.WriteString(fmt.Sprintf("%s\t bestämd form genitiv\n", w.TypeDef.(*types.Noun).SgDefiniteGen))
+
+	if w.Rules["plural"] {
+		output.WriteString("\n")
+		output.WriteString("Plural\n")
+		output.WriteString(fmt.Sprintf("%s\t obestämd form\n", w.TypeDef.(*types.Noun).PlIndefinite))
+		output.WriteString(fmt.Sprintf("%s\t obestämd form genitiv\n", w.TypeDef.(*types.Noun).PlIndefiniteGen))
+		output.WriteString(fmt.Sprintf("%s\t bestämd form\n", w.TypeDef.(*types.Noun).PlDefinite))
+		output.WriteString(fmt.Sprintf("%s\t bestämd form genitiv\n", w.TypeDef.(*types.Noun).PlDefiniteGen))
+	}
+
+	if w.Rules["ovrigt"] {
+		output.WriteString("\n")
+		output.WriteString("Övrig(a) form(er)\n")
+
+    newLine := "\n"
+		for i, form := range w.TypeDef.(*types.Noun).OtherForms {
+      // Rule to not add a new line at the last iteration.
+      if i == len(w.TypeDef.(*types.Noun).OtherForms) - 1 { 
+        newLine = "" 
+      } 
+			output.WriteString(fmt.Sprintf("%s\t %s%s", form[0], form[1], newLine))
+		}
+	}
+
+	return output.String()
+}
+

--- a/main.go
+++ b/main.go
@@ -1,15 +1,34 @@
 package main
 
 import (
-  "flag"
+	"flag"
+  "fmt"
+  "github.com/michalspano/saol.se-cli/pkg/saolcli"
+  "github.com/michalspano/saol.se-cli/cmd/utils"
 )
 
+// An example entry point of the SAOL package.
 func main() {
-  word := flag.String("word", "", "A word passed to SAOL.")
-  flag.Parse()
+	query := flag.String("query", "", "A word passed to SAOL [required]")
+  isID  := flag.Bool("id", false, "Whether to use the ID of the word [default: false]")
+  wordType := flag.String("type", "", "The type of the word [optional]")
+	flag.Parse()
 
-  if (*word == "") {
-    panic("No word provided.")
-  }
-  // TODO: call the SAOL module with the word
+	if *query == "" {
+		panic("No word provided.")
+	}
+
+  // Do some formatting of the wordType.
+  // Remove whitespaces, turn to lowercase.
+  fwordType := utils.FormatWordType(*wordType) 
+  
+  // Call the Execute function from the saol package.
+	result, err := saol.Execute(*query, *isID, fwordType)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+  
+  // Display the result
+	fmt.Println(result)
 }

--- a/pkg/saolcli/main.go
+++ b/pkg/saolcli/main.go
@@ -1,0 +1,219 @@
+package saol
+
+import (
+	"fmt"
+	"strings"
+	"github.com/PuerkitoBio/goquery"
+	"github.com/gocolly/colly"
+	"github.com/michalspano/saol.se-cli/types"
+	"github.com/michalspano/saol.se-cli/cmd/utils"
+)
+
+// A global state variable that is used to filter out the words
+// that are not of the desired type.
+// TODO: avoid using global state variables.
+var (
+  found = false
+)
+
+func Execute(query string, isID bool, T string) (string, error) {
+	// By default, the id is not used, hence the `sok` parameter is used.
+	// If the id is used (`isID` is true), then the `id` parameter is used.
+	// That is carried in the following if-construct.
+	url := fmt.Sprintf("https://svenska.se/saol/?sok=%s", query)
+	if isID {
+		url = fmt.Sprintf("https://svenska.se/saol/?id=%s", query)
+	}
+
+	c := colly.NewCollector() // Declare a collector instance
+
+	// Here we declare the response variable, which will be returned
+	// by the function. It is of type Word, which is a struct defined
+	// above.
+	var response types.Word
+
+	// A div class="lemma" contains all the information about a word,
+	// thereby, we can use it as a selector.
+	c.OnHTML("div.lemma", func(e *colly.HTMLElement) {
+    found = true 
+		baseForm := e.ChildText("span.grundform")
+		wordType := e.ChildText("a.ordklass")
+  
+    if T != wordType && T != "" {
+      return
+    }
+
+		response.BaseForm = baseForm
+		response.WordType = wordType
+
+		// The meanings are stored in a span with class="lexemid".
+		// The `\u200b` character is a zero-width space, which is used
+		// to separate the meanings. For our purposes, we can remove it.
+		// Moreover, all the meanings are storred in a buffer array,
+		// which is later assigned to the response.
+		meanings := make([]string, 0)
+		e.DOM.Find("span.lexemid").Each(func(_ int, s *goquery.Selection) {
+			meanings = append(meanings, strings.Replace(s.Text(), "\u200b", "", -1))
+		})
+
+		response.Meanings = meanings
+
+		// By default, these are set to false
+		// The values can be later overwritten
+		response.Rules = map[string]bool{
+			"plural": false,
+			"ovrigt": false,
+		}
+
+		// A table of class="tabell" on the SAOL's website contains
+		// all the grammatical information about a word. We can use
+		// it as a selector.
+		table := e.DOM.Find("table.tabell")
+
+		// Each header row contains information, namely the possible grammar
+		// rules, that apply to the word. We can use it as a selector.
+		// By default, these rules are set to false. In this step we decide
+		// whether such fules are applicable for out selected word.
+		table.Find("th.ordformth").Each(func(_ int, th *goquery.Selection) {
+			if th.Text() == "Plural" {
+				response.Rules["plural"] = true
+			} else if th.Text() == "Övrig(a) form(er)" {
+				response.Rules["ovrigt"] = true
+			}
+		})
+
+		// The following iterates over the table and assigns the values.
+		// This way, we extract the grammatical information about the word.
+		// The information (in a string format) are then added to the `grammarBuff`
+		// array.
+		// However, such a traversal also includes the text labels, therefore,
+		// we need to filter them out (this is done by the `switch` statement).
+		grammarBuff := make([]string, 0)
+		table.Find("tr").Each(func(_ int, tr *goquery.Selection) {
+			tr.Find("td").Each(func(_ int, td *goquery.Selection) {
+				grammarBuff = append(grammarBuff, td.Text())
+			})
+		})
+   
+    // Decide what type of word is added to the `response.TypeDef` field of the `response` struct.
+		switch wordType {
+		case "substantiv":
+			{
+				response.TypeDef = utils.CreateNoun(grammarBuff, response.Rules, e.ChildText("span.bojning"))
+			}
+		default:
+			{
+				response.TypeDef = nil
+			}
+		}
+	})
+  
+  // Visit the website and catch any errors.
+  // This is the actual execution of the crawler.
+	err := c.Visit(url)
+	if err != nil {
+		return "", err
+	}
+  
+  // In case that the BaseForm is empty, then the word is not found.
+  // This can happen for multiple reasons: the word is not in the dictionary,
+  // the word can be of more than one type. We use the additional `found` boolean
+  // to only access the block of code in the event of the 2nd case (multiple types).
+	if response.BaseForm == "" && !found {
+		tmpC := colly.NewCollector() // Declare a new temporary collector instance
+
+    // The following code block is used to extract all the possible types of the word.
+    // A div class="cshow" contains all the possible types of the word. Then, each a tag
+    // holds the type and the hred value the id of the word. The `options` array is used 
+    // to store the type and the id of the word.
+		options := make([][]string, 0)
+		tmpC.OnHTML("div.cshow", func(e *colly.HTMLElement) {
+			e.DOM.Find("a").Each(func(_ int, aTag *goquery.Selection) {
+        // remove redundant spaces
+				wordType := strings.Replace(aTag.Find("span.wordclass").Text(), " ", "", -1)
+        // additional remapping; the website (sometimes) uses abbreviations
+        if wordType == "subst." {
+          wordType = "substantiv"
+        }
+				wordID := aTag.AttrOr("href", "")
+				options = append(options, []string{wordType, wordID})
+			})
+		})
+
+    // Call the temporary collector instance to visit the website.
+    // Handle any errors.
+    err := tmpC.Visit(url)
+    if err != nil {
+      return "", err
+    }
+    
+    // Providing the type is an optional argument. However, if it is provided,
+    // a few steps can be skipped. The following block of code checks whether
+    // the type (T) belongs to current word's types. If it does, then the function
+    // is called recursively with the type as an argument and the stripped ID.
+    // Giving the T paramter means skipping the scanning of the standard input,
+    // so an advantage in terms of scalability is achieved.
+    if (T != "") {
+      for i := range options {
+        if options[i][0] == T {
+		      stripID := strings.Split(options[i][1], "?id=")[1]
+          return Execute(stripID, true, T)
+        }
+      }
+    }
+
+    // Print all the possible forms, so that the user can select the desired one. 
+		fmt.Printf("The word %s occurs in the following forms:\n", query)
+		for i := range options {
+			fmt.Printf("  %d. %s: %s\n", i+1, options[i][0], options[i][1])
+		}
+  
+    // Prompt the user to select the desired form.
+    // The cycle is only broken when the user enters a valid number.
+    // Otherwise, C-z can be used to exit the program.
+		var choice int
+		fmt.Printf("Select a number between 1 and %d for the desired form.\n", len(options))
+		for {
+			fmt.Print("~> ") // a prompt cursor
+			_, err := fmt.Scanf("%d", &choice)
+			if choice < 1 || choice > len(options) || err != nil {
+				fmt.Println("Please enter a valid number.")
+				continue
+			}
+			break
+		}
+  
+    // The `chosenID` variable holds the id of the selected word.
+    // We need to additionally parse the id from the href value (not the whole sub-url).
+    // Moreover, we update the `desiredType` variable, so that the crawler knows what type
+    // of word it is dealing with (in the recursive call).
+		chosenID    := options[choice-1][1]
+		stripID     := strings.Split(chosenID, "?id=")[1]
+    desiredType := options[choice-1][0]
+    
+    // Recursively call the `Execute` function with the new id.
+		return Execute(stripID, true, desiredType) 
+	}
+  
+  // Decide what formatting function to use based on the type of the word.
+  // and return the string.
+	switch response.WordType {
+	case "substantiv":
+		{
+			return utils.FormatNoun(response), nil
+		}
+  case "verb":
+    {
+      return "", fmt.Errorf("TODO: add support for verbs.")
+    }
+  case "adjektiv":
+    {
+      return "", fmt.Errorf("TODO: add support for adjectives.")
+    }
+	default:
+		{
+			return "", fmt.Errorf("The word %s was not found in SAOL.", query)
+		}
+	}
+}
+

--- a/types/definitions.go
+++ b/types/definitions.go
@@ -1,0 +1,38 @@
+package types
+
+/* The following file contains the definitions via
+ * structs for the different types of words (given by
+ * SAOL) */
+
+/* By default, every word has the following:
+ * Grundform: the word itself (in its basic form)
+ * Ordklass: the type of word (e.g. noun, verb, etc.)
+ * Meanings: an array of strings, each string representing a meaning
+ * Rules: a map of rules that apply to the word (does it have a plural
+ *        form? does it have other forms?)
+ * Type: further grammatical information about the word's type (e.g.
+ *        noun: definite/indefinite forms, etc.)
+ */
+type Word struct {
+	BaseForm string          // Grundform
+	WordType string          // Ordklass
+	Meanings []string        // Betydelser
+	Rules    map[string]bool // Grammatiska regler
+	TypeDef  interface{}     // Ordklass-specifik information
+}
+
+// Sg = singular, Pl = plural
+type Noun struct {
+  Suffix            string      // Böjningsändelse
+  SgIndefinite      string      // Singular, obestämd form
+  SgIndefiniteGen   string      // Singular, obestämd form genitiv
+  SgDefinite        string      // Singular, bestämd form
+  SgDefiniteGen     string      // Singular, bestämd form genitiv
+  PlIndefinite      string      // Plural, obestämd form
+  PlIndefiniteGen   string      // Plural, obestämd form genitiv
+  PlDefinite        string      // Plural, bestämd form
+  PlDefiniteGen     string      // Plural, bestämd form genitiv
+  OtherForms        [][]string  // Övriga former
+}
+
+// TODO: add more definitions of grammar


### PR DESCRIPTION
## Feature: Add support for nouns

This **PR** adds the required changes in order to support **nouns** for the `CLI` utility. The main changes are:
- A `utils` package is created that contains **utility** functions used by the `saol` package. This way, helper functions are separated from the `saol` package. Similarly, they enhance **reusability** for future implementation(s).
- The `types` package introduces the `Noun` `struct` (which serves as an abstraction of a noun, according to _saol_). Furthermore, it contains the `Word` struct, which is a general abstraction of any word of _saol_. Each `Word` is then further specified in its grammatical rules, such as with the help of the `Noun` `struct`.
- The `saol` package itself with the **tasks** defined in #3. It adds the basic support for **parsing** nouns from _saol_.
- The `main.go` entry point (front-end) is updated to match the requirements of the `saol` package. It introduces new command-line flags to process user input.

Closes #3.